### PR TITLE
Fix wrong variable name in f06214 start script

### DIFF
--- a/KARA/f06214/f06214.sh
+++ b/KARA/f06214/f06214.sh
@@ -14,7 +14,7 @@ dir="./${inoversion}"
 mkdir -p ${dir}
 
 # configuration to use
-cfg="./f06214.cfg"
+config="./f06214.cfg"
 
 ${binary} -I ${lasti}e-6 --config $config -T 1000 -o ${dir}/${lasti}_a1.h5
 for curri in {0350..0175..1}


### PR DESCRIPTION
Change variable name in the assignment to the value that is referenced to later